### PR TITLE
Use selectedQuestions when loading exam data

### DIFF
--- a/src/components/admin/ImportModal.jsx
+++ b/src/components/admin/ImportModal.jsx
@@ -45,6 +45,11 @@ const ImportModal = ({ onClose, onImport }) => {
       return;
     }
 
+    if (!currentUser) {
+      setError('You must be signed in to import questions.');
+      return;
+    }
+
     setLoading(true);
     setError('');
     setSuccess('');

--- a/src/components/admin/QuestionModal.jsx
+++ b/src/components/admin/QuestionModal.jsx
@@ -53,6 +53,12 @@ const QuestionModal = ({ question, categories, onClose, onSave }) => {
     setLoading(true);
 
     try {
+      if (!currentUser) {
+        setError('You must be signed in to save questions.');
+        setLoading(false);
+        return;
+      }
+
       // Validation
       if (!formData.category || !formData.question) {
         setError('Please fill in all required fields');

--- a/src/pages/student/TakeExam.jsx
+++ b/src/pages/student/TakeExam.jsx
@@ -107,9 +107,17 @@ const TakeExam = () => {
     };
 
     const pushInline = (value) => {
-      if (value && typeof value === 'object') {
-        references.push({ type: 'inline', value });
+      if (!value || typeof value !== 'object') {
+        return;
       }
+
+      // Some legacy structures wrap the question object in a { question: {...} } container.
+      if (value.question && typeof value.question === 'object') {
+        references.push({ type: 'inline', value: value.question });
+        return;
+      }
+
+      references.push({ type: 'inline', value });
     };
 
     function pushEntry(entry) {
@@ -151,6 +159,11 @@ const TakeExam = () => {
 
         if (typeof entry.questionId === 'string' && entry.questionId.trim()) {
           pushId(entry.questionId);
+          return;
+        }
+
+        if (typeof entry.questionID === 'string' && entry.questionID.trim()) {
+          pushId(entry.questionID);
           return;
         }
 

--- a/src/pages/student/TakeExam.jsx
+++ b/src/pages/student/TakeExam.jsx
@@ -93,11 +93,13 @@ const TakeExam = () => {
     if (!rawValue) return [];
 
     const references = [];
+    const seenIds = new Set();
     const pushId = (value) => {
       if (typeof value === 'string') {
         const trimmed = value.trim();
-        if (trimmed) {
+        if (trimmed && !seenIds.has(trimmed)) {
           references.push({ type: 'id', value: trimmed });
+          seenIds.add(trimmed);
         }
       }
     };
@@ -164,7 +166,7 @@ const TakeExam = () => {
     try {
       setLoading(true);
       const examData = await firestoreService.getOne('exams', examId);
-      
+
       if (!examData) {
         alert('Exam not found');
         navigate('/student/exams');
@@ -172,6 +174,8 @@ const TakeExam = () => {
       }
 
       setExam(examData);
+      setAnswers({});
+      setDragDropAnswers({});
       const durationInMinutes = Number(examData.duration) || 0;
       setTimeLeft(durationInMinutes * 60); // Convert minutes to seconds
 


### PR DESCRIPTION
## Summary
- read exam question ids from the stored `selectedQuestions` list, with `questions` as a legacy fallback
- filter out empty ids before fetching question documents to avoid runtime crashes when exams lack questions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e14661061c8328b7efa2fa29d5b7fe